### PR TITLE
clustering: enable clustering

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,10 +9,10 @@ import (
 )
 
 type cache struct {
-	*redis.Client
+	*redis.ClusterClient
 }
 
-func newCache(conn *redis.Client) *cache {
+func newCache(conn *redis.ClusterClient) *cache {
 	return &cache{
 		conn,
 	}

--- a/examples/basic_service/main.go
+++ b/examples/basic_service/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -57,7 +58,7 @@ func main() {
 	log.Fatal(srv.ListenAndServe())
 }
 
-func createConns() (*sqlx.DB, *sqlx.DB, *redis.Client) {
+func createConns() (*sqlx.DB, *sqlx.DB, *redis.ClusterClient) {
 	// set logrus log level to debug
 	logrus.SetLevel(logrus.DebugLevel)
 
@@ -73,10 +74,8 @@ func createConns() (*sqlx.DB, *sqlx.DB, *redis.Client) {
 		panic("dbConn is nil")
 	}
 
-	rdb := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%s", REDISHOST, REDISPORT),
-		Password: REDISPASS, // no password set
-		DB:       0,         // use default DB
+	rdb := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs: strings.Split("localhost:6379", ","),
 	})
 	if rdb == nil {
 		log.Fatal("unable to connect to redis")
@@ -88,7 +87,7 @@ func createConns() (*sqlx.DB, *sqlx.DB, *redis.Client) {
 type Config struct {
 	writeConn *sqlx.DB
 	readConn  *sqlx.DB
-	redis     *redis.Client
+	redis     *redis.ClusterClient
 }
 
 type lead struct {

--- a/examples/basic_service/store/store.go
+++ b/examples/basic_service/store/store.go
@@ -16,7 +16,7 @@ type Store interface {
 }
 
 type store struct {
-	redis *redis.Client // note: it's completely acceptable to have a redis client in the store
+	redis *redis.ClusterClient // note: it's completely acceptable to have a redis client in the store
 	db    *sqlx.DB
 	store storage.Storage
 }
@@ -24,7 +24,7 @@ type store struct {
 type Config struct {
 	ReadConn  *sqlx.DB
 	WriteConn *sqlx.DB
-	Redis     *redis.Client
+	Redis     *redis.ClusterClient
 	Tables    []*storage.Table
 }
 

--- a/storage.go
+++ b/storage.go
@@ -81,7 +81,7 @@ type storage struct {
 type Config struct {
 	ReadOnlyDbConn     *sqlx.DB
 	WriteOnlyDbConn    *sqlx.DB
-	Redis              *redis.Client
+	Redis              *redis.ClusterClient
 	Tables             []*Table
 	ServiceName        string
 	Debugger           bool // turn on / off the debugger


### PR DESCRIPTION
The storage package can deal with a lot of data and so it's best
to move forward with being able to support clustering sooner than
later. This will enable data & requests to horizontally scale.